### PR TITLE
Update branch name in linked URL

### DIFF
--- a/src/documentation/setting-up-the-maproulette-front-end.md
+++ b/src/documentation/setting-up-the-maproulette-front-end.md
@@ -6,7 +6,7 @@ tags: documentation
 eleventyNavigation:
   key: Setting up the MapRoulette Front-end
   parent: Code
-  url: https://github.com/osmlab/maproulette3/blob/master/README.md
+  url: https://github.com/osmlab/maproulette3/blob/main/README.md
   order: 2
 permalink: false
 ---


### PR DESCRIPTION
Found at https://learn.maproulette.org/documentation/ -- the link still redirects to the right place, but with a message "Branch not found, redirected to default branch.".  This PR updates the old link.